### PR TITLE
Option to specify a release number and relaxed requires clause

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "nginx_version": "1.12.0",
+  "nginx_version": "1.12.2",
   "modules": {
     "vts": {
       "library_name": "ngx_http_vhost_traffic_status_module.so",
@@ -9,7 +9,8 @@
       "sources": [
         "Changes", "LICENSE", "README.md"
       ],
-      "version": "v0.1.14"
+      "version": "v0.1.14",
+      "release": "1"
     },
     "naxsi": {
       "library_name": "ngx_http_naxsi_module.so",
@@ -19,7 +20,8 @@
       "sources": [
         "LICENSE", "README.md"
       ],
-      "version": "0.55.3"
+      "version": "0.55.3",
+      "release": "1"
     }
   }
 }

--- a/package_build.sh
+++ b/package_build.sh
@@ -12,6 +12,7 @@ set -ae
 : ${NGINX_VERSION=$(jq -r '.nginx_version' < "$BASE_DIR"/config.json)}
 : ${NGINX_URL="http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz"}
 : ${SHARED_LIBRARY=$(jq -r ".modules.$MODULE_NAME.library_name" < "$BASE_DIR"/config.json)}
+: ${RELEASE_NUMBER=$(jq -r ".modules.$MODULE_NAME.release" < "$BASE_DIR"/config.json)}}
 
 # Clean build directory
 if [ -d "$BUILD_DIR" ]; then

--- a/spec/nginx-module-naxsi.spec
+++ b/spec/nginx-module-naxsi.spec
@@ -7,11 +7,12 @@
 Epoch: %{epoch}
 %endif
 %define version %{getenv:MODULE_VERSION}
+%define release %{getenv:RELEASE_NUMBER}
 
 Summary: NGINX NAXSI (Nginx Anti XSS & SQL Injection) WAF
 Name: nginx-module-naxsi
 Version: %{?version}
-Release: 1%{?dist}.wso
+Release: %{release}%{?dist}.wso
 License: BSD
 Group: System Environment/Daemons
 URL: https://github.com/nbs-system/naxsi
@@ -21,7 +22,7 @@ Source1: LICENSE
 Source2: README.md
 
 BuildArch: x86_64
-Requires: nginx == %{?epoch:%{epoch}:}%{getenv:NGINX_VERSION}-1%{?dist}.ngx
+Requires: nginx == %{?epoch:%{epoch}:}%{getenv:NGINX_VERSION}
 
 %description
 NGINX NAXSI (Nginx Anti XSS & SQL Injection) WAF


### PR DESCRIPTION
Add option to specify a release number, this is useful when a new update of nginx comes out.  We may need to recompile an existing module version against a newer version of ngnix.  In this case, the module version remains the same but the release number can be increment.   Yum will then be able to recognise this is an updated package.

The relax requires clause in the spec file is to take account for variability in the format of the arch string at nginx.  E.g. See _http://nginx.org/packages/centos/7/x86_64/RPMS/_

arch string could be:  _el7_ or _el7_4_

I ran into issues because yum dependancy checks:

`--> Finished Dependency Resolution
Error: Package: 1:nginx-module-naxsi-0.55.3-4.el7.wso.x86_64 (/naxsi-0.55.3-4)
           Requires: nginx = 1:1.12.2-1.el7
           Installed: 1:nginx-1.12.2-1.el7_4.ngx.x86_64 (@nginx)`

I dont think the arch is needed in the "requires" clause, the version will be enough.  Unless you can think of a better way of handling this.

